### PR TITLE
Add float_warnings patchsets for Ruby 2.0.0p64[5 7 8], 2.1.[8 9 10], 2.2.[4 5 6 7 8], 2.3.[0 1 2 3 4 5] and 2.4.[0 1 2]

### DIFF
--- a/patchsets/ruby/2.0.0/p645/float_warnings
+++ b/patchsets/ruby/2.0.0/p645/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.0.0/p645/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.0.0/p647/float_warnings
+++ b/patchsets/ruby/2.0.0/p647/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.0.0/p647/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.0.0/p648/float_warnings
+++ b/patchsets/ruby/2.0.0/p648/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.0.0/p648/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.1.10/float_warnings
+++ b/patchsets/ruby/2.1.10/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.1.10/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.1.8/float_warnings
+++ b/patchsets/ruby/2.1.8/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.1.8/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.1.9/float_warnings
+++ b/patchsets/ruby/2.1.9/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.1.9/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.2.4/float_warnings
+++ b/patchsets/ruby/2.2.4/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.2.4/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.2.5/float_warnings
+++ b/patchsets/ruby/2.2.5/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.2.5/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.2.6/float_warnings
+++ b/patchsets/ruby/2.2.6/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.2.6/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.2.7/float_warnings
+++ b/patchsets/ruby/2.2.7/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.2.7/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.2.8/float_warnings
+++ b/patchsets/ruby/2.2.8/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.2.8/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.3.0/float_warnings
+++ b/patchsets/ruby/2.3.0/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.3.0/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.3.1/float_warnings
+++ b/patchsets/ruby/2.3.1/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.3.1/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.3.2/float_warnings
+++ b/patchsets/ruby/2.3.2/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.3.2/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.3.3/float_warnings
+++ b/patchsets/ruby/2.3.3/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.3.3/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.3.4/float_warnings
+++ b/patchsets/ruby/2.3.4/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.3.4/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.3.5/float_warnings
+++ b/patchsets/ruby/2.3.5/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.3.5/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.3/head/float_warnings
+++ b/patchsets/ruby/2.3/head/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.3/head/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.4.0/float_warnings
+++ b/patchsets/ruby/2.4.0/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.4.0/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.4.1/float_warnings
+++ b/patchsets/ruby/2.4.1/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.4.1/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.4.2/float_warnings
+++ b/patchsets/ruby/2.4.2/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.4.2/float_warnings/01-bigdecimal_float_warning.patch

--- a/patchsets/ruby/2.4/head/float_warnings
+++ b/patchsets/ruby/2.4/head/float_warnings
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/knugie/rvm-patchsets/master/patches/ruby/2.4/head/float_warnings/01-bigdecimal_float_warning.patch


### PR DESCRIPTION
Latest float_warnings patches.